### PR TITLE
ローカル開発環境をhttps化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,9 @@ sw.*
 
 # Vim swap files
 *.swp
+
+# Firebaseのキャッシュファイルなど
+.firebase
+
+# ローカル開発環境のHTTPS化用証明書
+cert/*.pem

--- a/cert/ローカル開発環境のHTTPS化対応.md
+++ b/cert/ローカル開発環境のHTTPS化対応.md
@@ -1,0 +1,41 @@
+# ローカル開発環境のHTTPS化対応
+
+## 証明書を作成する
+
+mkcert を使って、自己署名入り証明書（オレオレ証明書）を作成する
+
+```bash
+$ brew install mkcert
+$ mkcert -install
+Created a new certificate valid for the following names 📜
+ - "localhost"
+
+The certificate is at "./localhost.pem" and the key at "./localhost-key.pem" ✅
+```
+
+## 証明書を設置する
+
+root/cert/ 配下に作成した cert と key を設置する
+
+## 設定ファイルに証明書を設定する
+
+root/nuxt.config.js に以下の記載を追加する
+
+```js
+import path from 'path'
+import fs from 'fs'
+
+export default {
+server: {
+  https: {
+    key: fs.readFileSync(path.resolve(__dirname, 'cert/', 'localhost-key.pem')),
+    cert: fs.readFileSync(path.resolve(__dirname, 'cert/', 'localhost.pem')),
+  },
+},
+```
+
+## 開発サーバーを起動する
+
+```bash
+yarn run dev
+```

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,3 +1,5 @@
+import path from 'path'
+import fs from 'fs'
 import colors from 'vuetify/es5/util/colors'
 
 export default {
@@ -72,6 +74,15 @@ export default {
           success: colors.green.accent3,
         },
       },
+    },
+  },
+
+  // サーバーの設定
+  server: {
+    // ローカル開発環境のHTTPS化対応
+    https: {
+      key: fs.readFileSync(path.resolve(__dirname, 'cert/', 'localhost-key.pem')),
+      cert: fs.readFileSync(path.resolve(__dirname, 'cert/', 'localhost.pem')),
     },
   },
 


### PR DESCRIPTION
## 変更の経緯・理由
<!-- プルリクエストの経緯や理由を記載する -->
<!-- Issueが立っている場合は、"関連Issue"の記載のみで可 -->

- 今後の開発の利便性向上が目的
  - httpsでないと扱えないAPI等が出てくる可能性があるため

### 関連Issue
<!-- Issueが立っている場合は、番号を記載して紐付けを行う -->
close: #

## 期待される機能
<!-- 該当プルリクエストでやらないことがあれば、合わせて記載する（Issueを立てて番号を追記できるとベスト） -->

- ローカル開発環境がSSL（https）通信に対応する

## 実装内容
<!-- 特に見て欲しい箇所・期待するレビューの観点等があれば、合わせて記載する -->

- 証明書を配置する```ROOT/cert```ディレクトリの追加
  - オレオレ証明書を使った手順書を追加
- .gitignoreに証明書関係のファイルを追加
- Nuxtの設定ファイルにて、サーバーの設定を追加
  - オプションでローカル開発環境のhttps化を指定している

## テストの実施
<!-- 手動でテストを行った場合は、テストの手順を記載する -->

- [ ] テストコードを記載している
- [x] 手動でテストを行った
- [ ] 軽微な修正のため必要なし

下記コマンドにて、ローカル開発環境がhttps対応で立ち上がっていることを確認した
（注意が出てますが、今回の部分とは関係ないので一旦未対応）

```bash
yarn dev
yarn run v1.22.10
$ nuxt-ts

 WARN  You're using Nuxt 2.15.2, which includes built-in TypeScript runtime support                                                                                                                   17:32:36


 WARN  You can safely use nuxt instead of nuxt-ts and remove @nuxt/typescript-runtime package                                                                                                         17:32:36

ℹ Parsed 1 files in 0,3 seconds                                                                                                                                                         @nuxt/content 17:32:37

   ╭────────────────────────────────────────╮
   │                                        │
   │   Nuxt @ v2.15.2                       │
   │                                        │
   │   ▸ Environment: development           │
   │   ▸ Rendering:   server-side           │
   │   ▸ Target:      static                │
   │                                        │
   │   Listening: https://localhost:3000/   │
   │                                        │
   ╰────────────────────────────────────────╯

ℹ Preparing project for development                                                                                                                                                                   17:32:38
ℹ Initial build may take a while                                                                                                                                                                      17:32:38
ℹ Discovered Components: .nuxt/components/readme.md                                                                                                                                                   17:32:38
✔ Builder initialized                                                                                                                                                                                 17:32:38
✔ Nuxt files generated 
```

## 頑張った点・工夫した点
<!-- 褒めてもらいたい箇所 -->

## 伝達事項
<!-- 今後の開発に役立つ（または注意すべき）情報 -->
