### PR TITLE
TypeScriptの設定で、Vuetifyの型情報を読み込みように記載を追加

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
       "@nuxt/types",
       "@nuxtjs/axios",
       "@nuxt/content",
+      "@nuxtjs/vuetify",
       "@types/node"
     ]
   },


### PR DESCRIPTION
## 変更の経緯・理由
<!-- プルリクエストの経緯や理由を記載する -->
<!-- Issueが立っている場合は、"関連Issue"の記載のみで可 -->

TypeScript上で、Vuetifyに規定されている色の型情報が読み込めていなかった。
型情報が読み込まれるように修正した。

### 関連Issue
<!-- Issueが立っている場合は、番号を記載して紐付けを行う -->
close: #

## 期待される機能
<!-- 該当プルリクエストでやらないことがあれば、合わせて記載する（Issueを立てて番号を追記できるとベスト） -->

- `nuxt.config.ts`でインポートされている'colors'の型情報が読み込まれること

## 実装内容
<!-- 特に見て欲しい箇所・期待するレビューの観点等があれば、合わせて記載する -->

- TypeScriptの設定（tsconfig.json）の型設定において、Vuetifyの情報を読み込むように記載を追加した

## テストの実施
<!-- 手動でテストを行った場合は、テストの手順を記載する -->

- [ ] テストコードを記載している
- [x] 手動でテストを行った
- [ ] 軽微な修正のため必要なし

`nuxt.config.ts`にて、インポートされている'colors'の型情報が読み込まれていることを確認した

## 頑張った点・工夫した点
<!-- 褒めてもらいたい箇所 -->

## 伝達事項
<!-- 今後の開発に役立つ（または注意すべき）情報 -->
